### PR TITLE
The reference to non-existent dir in the MANIFEST.in causes pip errors.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include README.rst LICENSE
 recursive-include switchboard/admin/templates *
-recursive-include switchboard/admin/public *

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.2.1'
+version = '1.2.2'
 
 setup(name='switchboard',
       version=version,


### PR DESCRIPTION
The 'public' directory no longer exists and the reference to it causes pip some mild unhappiness. 