### PR TITLE
Handle a null cache with logging and fallback.

### DIFF
--- a/switchboard/base.py
+++ b/switchboard/base.py
@@ -32,12 +32,17 @@ class CachedDict(object):
     def __getitem__(self, key):
         self._populate()
         try:
-            return self._cache[key]
+            value = self._cache[key]
         except KeyError:
             value = self.get_default(key)
             if value is NoValue:
                 raise
-            return value
+        except (TypeError, AttributeError):
+            log.exception('Unable to access the local cache')
+            value = self.get_default(key)
+            if value is NoValue:
+                raise KeyError(key)
+        return value
 
     def __len__(self):  # pragma: nocover
         if self._cache is None:

--- a/switchboard/tests/test_base.py
+++ b/switchboard/tests/test_base.py
@@ -333,3 +333,11 @@ class TestCachedDict(object):
         last_updated = self.mydict.last_updated_cache_key
         self.cache.get.assert_called_once_with(last_updated)
         assert_equals(result, True)
+
+    @patch('switchboard.base.CachedDict._populate')
+    @patch('switchboard.base.CachedDict.get_default')
+    def test_returns_default_if_no_local_cache(self, get_default, populate):
+        get_default.return_value = 'bar'
+        value = self.mydict['foo']
+        assert_true(get_default.called)
+        assert_equals(value, 'bar')


### PR DESCRIPTION
Fixes bug #8. The local cache should never be null; the last lines of the _populate function should see to that. Nonetheless, we're seeing errors in production. Put some error handling and logging into place and attempt to fall back to a default value.