### PR TITLE
Fix null cache.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='switchboard',
       packages=find_packages(exclude=['ez_setup']),
       include_package_data=True,
       install_requires=[
-          'pymongo >= 2.3',
+          'pymongo == 2.3',
           'blinker >= 1.2',
           'WebOb >= 0.9',
           'Mako >= 0.9',

--- a/switchboard/base.py
+++ b/switchboard/base.py
@@ -8,6 +8,7 @@ switchboard.base
 
 import time
 import logging
+import threading
 
 from .models import MongoModel
 from .signals import request_finished
@@ -18,7 +19,7 @@ log = logging.getLogger(__name__)
 NoValue = object()
 
 
-class CachedDict(object):
+class CachedDict(threading.local):
     def __init__(self, cache=None, timeout=30):
         cls_name = type(self).__name__
 

--- a/switchboard/tests/test_base.py
+++ b/switchboard/tests/test_base.py
@@ -21,7 +21,6 @@ from blinker import Signal
 from ..base import MongoModelDict, CachedDict
 from ..models import VersioningMongoModel
 from ..signals import request_finished
-from ..manager import operator
 
 
 class MockModel(VersioningMongoModel):
@@ -151,8 +150,10 @@ class TestMongoModelDict(object):
     def test_signals_are_connected(self):
         MongoModelDict(MockModel, key='key', value='value',
                        auto_create=True)
-        assert_true(VersioningMongoModel.post_save.has_receivers_for(MockModel))
-        assert_true(VersioningMongoModel.post_delete.has_receivers_for(MockModel))
+        post_save = VersioningMongoModel.post_save
+        post_delete = VersioningMongoModel.post_delete
+        assert_true(post_save.has_receivers_for(MockModel))
+        assert_true(post_delete.has_receivers_for(MockModel))
         assert_true(request_finished.has_receivers_for(Signal.ANY))
 
 

--- a/switchboard/tests/test_base.py
+++ b/switchboard/tests/test_base.py
@@ -7,6 +7,7 @@ switchboard.tests.test_base
 """
 
 import time
+import threading
 
 from nose.tools import (
     assert_equals,
@@ -341,3 +342,46 @@ class TestCachedDict(object):
         value = self.mydict['foo']
         assert_true(get_default.called)
         assert_equals(value, 'bar')
+
+
+class TestConcurrency(object):
+
+    def setup(self):
+        self.mydict = CachedDict()
+        self.exc = None
+
+    @patch('switchboard.base.CachedDict.get_cache_data')
+    def test_cache_reset_race(self, get_cache_data):
+        '''
+        Test race conditions when populating a cache.
+
+        Setup a situation where the cache is cleared immediately after being
+        populated, to simulate the race condition of one thread resetting it
+        just after another has populated it.
+        '''
+        get_cache_data.return_value = dict(key='test')
+        t2 = threading.Thread(target=self.mydict.clear_cache)
+
+        def verify_dict_access():
+            self.mydict._populate()
+            # Fire up the second thread and wait for it to clear the cache.
+            t2.start()
+            t2.join()
+            # Verify that the first thread's cache is still populated.
+            # Note: we don't call self.mydict['key'] because we don't want to
+            # re-trigger cache population.
+            # Note: Any errors (assertion or otherwise) must be surfaced up to
+            # the parent thread in order for nose to see that something went
+            # wrong.
+            try:
+                assert_true(self.mydict._cache,
+                            'The cache was reset between threads')
+                assert_equals(self.mydict._cache['key'], 'test')
+            except Exception as e:
+                self.exc = e
+
+        t1 = threading.Thread(target=verify_dict_access)
+        t1.start()
+        t1.join()
+        if self.exc:
+            raise self.exc


### PR DESCRIPTION
Fixes https://github.com/switchboardpy/switchboard/issues/8.

The underlying problem was a race condition. When the in-memory local cache (i.e., not the global cache in memcached) is populated under certain conditions (no global cache or the local has expired), the first thing that happens it to reset it, by setting it to `None`. Then the local cache is populated from the global cache and/or the database.

Since threads share memory, they were also all sharing the same local cache. If Thread1 populated the local cache and then Thread2 came along (and the proper conditions were in place), then Thread2 could re-clear the cache (`cache=None`). Finally, if Thread1 attempted to access the cache (`return cache[key]`) before Thread2 could repopulate, we'd get the TypeError described in the bug.