### PR TITLE
Freeze on Selenium 2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ coverage
 bottle
 paste
 splinter
-selenium
+selenium==2.53.0


### PR DESCRIPTION
Fixes #37.

Right now Selenium 3 depends on geckodriver (https://github.com/mozilla/geckodriver) and Marionette. Geckodriver's README states: "Marionette and geckodriver are not yet feature complete." Until that stack settles a bit, let's stick with Selenium 2.