### PR TITLE
Allow any pymongo 2.x version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='switchboard',
       packages=find_packages(exclude=['ez_setup']),
       include_package_data=True,
       install_requires=[
-          'pymongo == 2.3',
+          'pymongo >= 2.3, < 3',
           'blinker >= 1.2',
           'WebOb >= 0.9',
           'Mako >= 0.9',


### PR DESCRIPTION
Previously installing switchboard or running `setup.py develop` would force pymongo 2.3 to be installed.  Now it will let you keep whatever particular version your host app is using.