### PR TITLE
Move from Mongo/caching to datastore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 coverage.xml
 docs/_build
 build
+example/.switches

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ coverage.xml
 docs/_build
 build
 example/.switches
+*.log
+.venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: python
 
-services:
-  - mongodb
+addons:
+  firefox: "latest"
 
 sudo: false
 
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
   - pip install codecov
+  - npm install -g geckodriver
 
 install: make install
 

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ release:
 example:
 	python example/server.py
 
-.PHONY: install test functional-test release example
+.PHONY: bootstrap install test functional-test release example

--- a/example/server.py
+++ b/example/server.py
@@ -1,11 +1,25 @@
+import pickle
+
 from bottle import Bottle, redirect, run
+import datastore.core
 
 from switchboard import operator, configure
 from switchboard.middleware import SwitchboardMiddleware
 from switchboard.admin import app as switchboard
 
-configure()
 
+# Setup a file-based datastore with pickle serialization.
+import datastore.filesystem
+import os
+base_path = os.path.dirname(os.path.realpath(__file__))
+ds_file = os.path.join(base_path, '.switches')
+ds_child = datastore.filesystem.FileSystemDatastore(ds_file)
+ds = datastore.serialize.shim(ds_child, pickle)
+
+# Configure Switchboard.
+configure(datastore=ds)
+
+# Fire up the example application.
 app = Bottle()
 app.mount('/_switchboard/', switchboard)
 

--- a/example/tests.py
+++ b/example/tests.py
@@ -15,6 +15,9 @@ example``, the example app should already be running in another console.
 :license: Apache License 2.0, see LICENSE for more details.
 """
 
+import os
+import shutil
+
 from nose.tools import assert_true, assert_false
 from splinter import Browser
 
@@ -44,12 +47,16 @@ def assert_switch_inactive(browser, url=url):
                 'Switch is not inactive')
 
 
+def drop_datastore():
+    Switch.drop()
+
+
 class TestAdmin(object):
     @classmethod
     def setup_class(cls):
         cls.b = Browser()
         # Ensure we're working with a clean slate.
-        Switch.c.drop()
+        drop_datastore()
 
     @classmethod
     def teardown_class(cls):
@@ -61,7 +68,7 @@ class TestAdmin(object):
         self.b.visit(url)
 
     def teardown(self):
-        Switch.c.drop()
+        drop_datastore()
 
     def test_root(self):
         assert_switch_inactive(self.b)
@@ -181,22 +188,6 @@ class TestAdmin(object):
         is_deleted = self.b.is_element_not_present_by_css('#id_{}'.format(key),
                                                           wait_time=10)
         assert_true(is_deleted, 'Switch was not deleted.')
-
-    def test_switch_history(self):
-        self.b.visit(admin_url)
-        # View switch history.
-        self.show_switch_actions()
-        css = '#id_example a[href="#history-switch"]'
-        self.b.find_by_css(css).first.click()
-        # Verify the history appears.
-        is_present = self.b.is_element_present_by_css('.drawer .version',
-                                                      wait_time=10)
-        assert_true(is_present, 'Switch history not found.')
-        drawer = self.b.find_by_css('.drawer').first
-        assert_true(drawer.visible, 'Drawer is not visible')
-        # Close the history.
-        drawer.find_by_css('.close-action').first.click()
-        assert_false(drawer.visible, 'Drawer is not hidden')
 
     def show_switch_actions(self):
         '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ coverage
 bottle
 paste
 splinter
-selenium==2.53.0
+selenium>=3.0

--- a/setup.py
+++ b/setup.py
@@ -20,18 +20,18 @@ setup(name='switchboard',
       include_package_data=True,
       install_requires=[
           'datastore >= 0.3.6',
-          'smhasher >= 0.150.1',  # Default version won't compile in Xenial.
+          'smhasher >= 0.150',  # Default version won't compile in Xenial.
           'blinker >= 1.2',
           'WebOb >= 0.9',
           'Mako >= 0.9',
-          'bottle == 0.12.8',
+          'bottle >= 0.12.8',
       ],
       zip_safe=False,
       tests_require=[
           'nose',
           'mock',
           'paste',
-          'selenium',
+          'selenium >= 3.0',
           'splinter',
       ],
       test_suite='nose.collector',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.3.7'
+version = '2.0.0'
 
 setup(name='switchboard',
       version=version,
@@ -19,7 +19,8 @@ setup(name='switchboard',
       packages=find_packages(exclude=['ez_setup']),
       include_package_data=True,
       install_requires=[
-          'pymongo >= 2.3, < 3',
+          'datastore >= 0.3.6',
+          'smhasher >= 0.150.1',  # Default version won't compile in Xenial.
           'blinker >= 1.2',
           'WebOb >= 0.9',
           'Mako >= 0.9',

--- a/switchboard/admin/index.tpl
+++ b/switchboard/admin/index.tpl
@@ -286,7 +286,6 @@
                 <div class="actions btn-group">
                   <a href="#edit-switch" class="btn btn-link edit" title="Edit Switch"><i class="fa fa-pencil"></i></a>
                   <a href="#delete-switch" class="btn btn-link delete" title="Delete Switch"><i class="fa fa-trash-o"></i></a>
-                  <a href="#history-switch" class="btn btn-link history" title="View Switch History"><i class="fa fa-clock-o"></i></a>
                 </div>
               </h5>
               <h6 class="timestamp micro">
@@ -389,7 +388,6 @@
                 <div class="actions btn-group">
                   <a href="#edit-switch" class="edit btn-link btn" title="Edit Switch"><i class="fa fa-pencil"></i></a>
                   <a href="#delete-switch" class="delete btn-link btn" title="Delete Switch"><i class="fa fa-trash-o"></i></a>
-                  <a href="#history-switch" class="btn btn-link history" title="View Switch History"><i class="fa fa-clock-o"></i></a>
                 </div>
               </h5>
               <h6 class="timestamp micro">

--- a/switchboard/base.py
+++ b/switchboard/base.py
@@ -6,77 +6,80 @@ switchboard.base
 :license: Apache License 2.0, see LICENSE for more details.
 """
 
-import time
-import logging
 import threading
 
-from .models import MongoModel
-from .signals import request_finished
-from .settings import settings
 
-log = logging.getLogger(__name__)
+class ModelDict(threading.local):
+    """
+    Dictionary-style access to :func:`~switchboard.model.Model` data.
 
+    If ``auto_create=True`` accessing modeldict[key] when key does not exist
+    will attempt to create it in the datastore.
 
-NoValue = object()
+    Functions in two different ways, depending on the constructor:
 
+        # Assume the datastore has a record like so:
+        # { key: '000-abc', 'name': 'Jim', 'phone': '1235677890' }
 
-class CachedDict(threading.local):
-    def __init__(self, timeout=30):
-        """
-        Not guaranteed to be called with expected c'tor args of
-        all usages (due to usage of threading.local)
-        """
-        cls_name = type(self).__name__
+        mydict = ModelDict(Model)
+        mydict['000-abc']
+        >>> Model({ 'key': '000-abc', 'name': 'Jim', 'phone': '1234567890' }) #doctest: +SKIP
 
-        self._cache = None
-        self._last_updated = None
-        self.timeout = timeout
-        self.cache = settings.SWITCHBOARD_CACHE
-        self.cache_key = cls_name
-        self.last_updated_cache_key = '%s.last_updated' % (cls_name,)
+    If you want to use another key besides ``key``, you may specify that in the
+    constructor:
+
+        mydict = ModelDict(Model, key='phone')
+        mydict['1234567890']
+        >>> Model({ 'key': '000-abc', 'name': 'Jim', 'phone': '1234567890' }) #doctest: +SKIP
+
+    The ModelDict needs to be thread local so that information is not shared
+    across threads, e.g., requests.
+    """
+    def __init__(self, model, key='key', auto_create=False, *args, **kwargs):
+        self._key = key
+        self._model = model
+        self._auto_create = auto_create
 
     def __getitem__(self, key):
-        self._populate()
-        try:
-            value = self._cache[key]
-        except KeyError:
-            value = self.get_default(key)
-            if value is NoValue:
-                raise
-        except (TypeError, AttributeError):
-            log.exception('Unable to access the local cache')
-            value = self.get_default(key)
-            if value is NoValue:
-                raise KeyError(key)
-        return value
+        if self._auto_create:
+            instance = self._model.get_or_create(key)[0]
+        else:
+            instance = self._model.get(key)
+        if instance is None:
+            raise KeyError(key)
+        return instance
+
+    def __setitem__(self, key, instance):
+        if not hasattr(instance, 'key'):
+            instance.key = key
+        instance.save()
+
+    def __delitem__(self, key):
+        self._model.remove(key)
 
     def __len__(self):  # pragma: nocover
-        if self._cache is None:
-            self._populate()
-        return len(self._cache)
+        return self._model.count()
 
     def __contains__(self, key):  # pragma: nocover
-        self._populate()
-        return key in self._cache
+        return self._model.contains(key)
 
     def __iter__(self):  # pragma: nocover
-        self._populate()
-        return iter(self._cache)
+        return self._model.all()
 
     def __repr__(self):  # pragma: nocover
         return "<%s>" % (self.__class__.__name__)
 
     def iteritems(self):  # pragma: nocover
-        self._populate()
-        return self._cache.iteritems()
+        def make_item(model):
+            return (getattr(self._key, model), model)
+        items = [make_item(model) for model in self._model.all()]
+        return iter(items)
 
     def itervalues(self):  # pragma: nocover
-        self._populate()
-        return self._cache.itervalues()
+        return self._model.all()
 
     def iterkeys(self):  # pragma: nocover
-        self._populate()
-        return self._cache.iterkeys()
+        return iter([getattr(self._key, model) for model in self._model.all()])
 
     def keys(self):  # pragma: nocover
         return list(self.iterkeys())
@@ -85,14 +88,16 @@ class CachedDict(threading.local):
         return list(self.itervalues())
 
     def items(self):  # pragma: nocover
-        self._populate()
-        return self._cache.items()
+        return list(self.iteritems())
 
     def get(self, key, default=None):
-        self._populate()
-        return self._cache.get(key, default)
+        try:
+            value = self[key]
+        except KeyError:
+            value = default
+        return value
 
-    def pop(self, key, default=NoValue):
+    def pop(self, key, default=None):
         value = self.get(key, default)
         try:
             del self[key]
@@ -100,233 +105,5 @@ class CachedDict(threading.local):
             pass
         return value
 
-    def setdefault(self, key, value):
-        if key not in self:
-            self[key] = value
-
-    def get_default(self, key):  # pragma: nocover
-        return NoValue
-
-    def is_local_expired(self):
-        """
-        Returns ``True`` if the in-memory cache has expired (based on
-        the cached last_updated value).
-        """
-        proc_last_updated = self._last_updated
-        if not proc_last_updated:
-            return True
-
-        if time.time() > proc_last_updated + self.timeout:
-            return True
-
-        return False
-
-    def has_global_changed(self):
-        """
-        Returns ``True`` if the global cache has changed (based on
-        the last_updated_cache_key value).
-
-        A return value of ``None`` signifies that no data was available.
-        """
-        # First deal with situations that don't have caching enabled.
-        if not self.cache:
-            return True
-        # Now deal with all "cache is present" situations.
-        try:
-            cache_last_updated = self.cache.get(self.last_updated_cache_key)
-        except:  # pragma: nocover
-            log.exception('Unable to get cache last updated')
-            return None
-        if not cache_last_updated:
-            return None
-
-        if int(cache_last_updated) > self._last_updated:
-            return True
-
-        return False
-
-    def get_cache_data(self):
-        """
-        Pulls data from the cache backend.
-        """
-        return self._get_cache_data()
-
-    def clear_cache(self):
-        """
-        Clears the in-process cache.
-        """
-        self._cache = None
-        self._last_updated = None
-
-    def _populate(self, reset=False):
-        """
-        Ensures the cache is populated and still valid.
-
-        The cache is checked when:
-
-        - The local timeout has been reached
-        - The local cache is not set
-
-        The cache is invalid when:
-
-        - The global cache has expired (via last_updated_cache_key)
-        """
-        if reset:
-            self._cache = None
-        elif not self.cache:
-            self._cache = None
-        elif self.is_local_expired():
-            now = int(time.time())
-            # Avoid hitting memcache if we don't have a local cache.
-            if self._cache is None:
-                global_changed = True
-            else:
-                global_changed = self.has_global_changed()
-
-            # If the cache is expired globally, or local cache isn't present.
-            if global_changed or self._cache is None:
-                # The value may or may not exist in the cache.
-                try:
-                    self._cache = self.cache.get(self.cache_key)
-                    assert isinstance(self._cache, dict)
-                except:
-                    self._cache = None
-                    log.exception('Unable to refresh local cache from global')
-
-                # If for some reason last_updated_cache_key was None (but the
-                # cache key wasn't) we should force the key to exist to prevent
-                # continuous calls.
-                try:
-                    last_updated = self.cache.get(self.last_updated_cache_key)
-                except:  # pragma: nocover
-                    last_updated = None
-                    log.exception('Unable to get cache last updated')
-                if (global_changed is None
-                        and self._cache is not None
-                        and not last_updated):
-                    try:
-                        self.cache.set(self.last_updated_cache_key, now)
-                    except:  # pragma: nocover
-                        log.exception('Unable to set cache last updated')
-
-            self._last_updated = now
-
-        if self._cache is None:
-            self._update_cache_data()
-
-        return self._cache
-
-    def _update_cache_data(self):
-        self._cache = self.get_cache_data()
-        self._last_updated = int(time.time())
-        # We only set last_updated_cache_key when we know the cache is current
-        # because setting this will force all clients to invalidate their
-        # cached data if it's newer
-        if self.cache:
-            try:
-                self.cache.set(self.cache_key, self._cache)
-                self.cache.set(self.last_updated_cache_key, self._last_updated)
-            except:  # pragma: nocover
-                log.exception('Unable to refresh global cache from database')
-
-    def _get_cache_data(self):
-        raise NotImplementedError  # pragma: nocover
-
-    def _cleanup(self, *args, **kwargs):
-        # We set _last_updated to a false value to ensure we hit the
-        # last_updated cache on the next request
-        self._last_updated = None
-
-
-class MongoModelDict(CachedDict):
-    """
-    Dictionary-style access to documents in a collection. Populates a cache
-    and a local in-memory store to avoid multiple hits to the collection.
-
-    Specifying ``instances=True`` will cause the cache to store instances
-    rather than simple values.
-
-    If ``auto_create=True`` accessing mongodict[key] when key does not exist
-    will attempt to create it in the collection.
-
-    Functions in two different ways, depending on the constructor:
-
-        # Given a document that has a attribute named ``foo`` where the value
-        # is "bar":
-
-        mydict = MongoModelDict(Model, value='foo')
-        mydict['test']
-        >>> 'bar' #doctest: +SKIP
-
-    If you want to use another key besides ``_id``, you may specify that in the
-    constructor. However, this will be used as part of the cache key, so it's
-    recommended to access it in the same way throughout your code.
-
-        mydict = MongoModelDict(Model, key='foo', value='id')
-        mydict['bar']
-        >>> 'test' #doctest: +SKIP
-
-    """
-    def __init__(self, model, key='pk', value=None,
-                 auto_create=False, *args, **kwargs):
-        assert value is not None
-
-        super(MongoModelDict, self).__init__(*args, **kwargs)
-
-        cls_name = type(self).__name__
-        name = model.__name__
-
-        self.key = key
-        self.value = value
-
-        self.model = model
-        self.auto_create = auto_create
-
-        self.cache_key = '%s:%s:%s' % (cls_name, name, self.key)
-        self.last_updated_cache_key = '%s.last_updated:%s:%s' % (cls_name,
-                                                                 name,
-                                                                 self.key)
-        request_finished.connect(self._cleanup)
-        MongoModel.post_save.connect(self._post_save)
-        MongoModel.post_delete.connect(self._post_delete)
-
-    def __setitem__(self, key, value):
-        if isinstance(value, self.model):
-            value = getattr(value, self.value)
-
-        instance, created = self.model.get_or_create(
-            defaults={self.value: value},
-            **{self.key: key}
-        )
-
-        # Ensure we're updating the value in the database if it changes
-        if getattr(instance, self.value) != value:
-            setattr(instance, self.value, value)
-            self.model.update({self.key: key}, {'$set': {self.value: value}})
-
-    def __delitem__(self, key):
-        self.model.remove(**{self.key: key})
-
-    def setdefault(self, key, value):
-        if isinstance(value, self.model):
-            value = getattr(value, self.value)
-        self.model.get_or_create(
-            defaults={self.value, value},
-            **{self.key: key}
-        )
-
-    def get_default(self, key):
-        if not self.auto_create:
-            return NoValue
-        result = self.model.get_or_create(**{self.key: key})[0]
-        return result
-
-    def _get_cache_data(self):
-        return dict((getattr(i, self.key), i) for i in self.model.all())
-
-    # Signals
-    def _post_save(self, sender, **kwargs):
-        self._populate(reset=True)
-
-    def _post_delete(self, sender, **kwargs):
-        self._populate(reset=True)
+    def setdefault(self, key, instance):
+        self._model.get_or_create(key, defaults=instance.__dict__)

--- a/switchboard/helpers.py
+++ b/switchboard/helpers.py
@@ -7,8 +7,6 @@ switchboard.helpers
 """
 
 import logging
-from collections import defaultdict
-from copy import deepcopy
 
 from webob import Request
 
@@ -25,86 +23,3 @@ class MockRequest(Request):
         blank.environ['REMOTE_ADDR'] = ip_address
         super(MockRequest, self).__init__(blank.environ)
         self.user = user
-
-
-class MockCollection(object):
-    """
-    A quick and dirty implementation of PyMongo's Collection API,
-    to allow for easy testing without a DB connection.
-    """
-    def __init__(self, name=''):
-        self._data = []
-        self.name = name
-        self.database = defaultdict(lambda: MockCollection(), name=self)
-
-    def _matches(self, spec, document):
-        for k, v in spec.iteritems():
-            if k not in document or document[k] != v:
-                return False
-        return True
-
-    def find_one(self, spec):
-        result = self.find(spec)
-        return result[0] if result else None
-
-    def find(self, spec=None):
-        results = []
-        if not spec:
-            # Return a copy of the list so that updating the returned list does
-            # not automatically update the datastore.
-            return deepcopy(self._data)
-        for d in self._data:
-            if self._matches(spec, d):
-                results.append(d)
-        return results or None
-
-    def _update_partial(self, old, new):
-        for k, v in new.iteritems():
-            old[k] = v
-
-    def update(self, spec, update, upsert=False):
-        current = self.find_one(spec)
-        if not current:
-            if upsert:
-                spec.update(update)
-                return self.save(spec)
-            else:
-                return {
-                    'err': None,
-                    'n': 1,
-                    'ok': 1.0,
-                    'updatedExisting': True
-                }
-        for k, v in update.iteritems():
-            if k == '$set':
-                self._update_partial(current, v)
-            else:
-                current[k] = v
-        return {
-            'err': None,
-            'n': 1,
-            'ok': 1.0,
-            'updatedExisting': True
-        }
-
-    def remove(self, spec):
-        doc = self.find_one(spec)
-        if doc:
-            self._data.remove(doc)
-            return {'err': None, 'n': 1, 'ok': 1.0}
-
-    def save(self, document):
-        if not document.get('_id'):
-            _id = str(len(self._data))
-            document['_id'] = _id
-            self._data.append(document)
-        else:
-            _id = document['_id']
-            self.update({'_id': _id}, document)
-        return _id
-
-    def drop(self):
-        self._data = []
-
-    def count(self):
-        return len(self._data)

--- a/switchboard/middleware.py
+++ b/switchboard/middleware.py
@@ -39,7 +39,7 @@ class SwitchboardMiddleware(object):
     def post_request(self, req, resp):
         '''
         Extension point to make it easy to hook additional functionality onto
-        the end of Switchboard' processing of a request.
+        the end of Switchboard's processing of a request.
         '''
         pass
 

--- a/switchboard/settings.py
+++ b/switchboard/settings.py
@@ -14,20 +14,13 @@ class Settings(object):
     _state = {}
 
     @classmethod
-    def init(cls, cache=None, mongo_host='localhost', mongo_port=27017,
-             mongo_db='switchboard', mongo_collection='switches',
-             **kwargs):
-        cls._state['SWITCHBOARD_MONGO_HOST'] = mongo_host
-        cls._state['SWITCHBOARD_MONGO_PORT'] = mongo_port
-        cls._state['SWITCHBOARD_MONGO_DB'] = mongo_db
-        cls._state['SWITCHBOARD_MONGO_COLLECTION'] = mongo_collection
-        cls._state['SWITCHBOARD_CACHE'] = cache
-        remainder = kwargs.iteritems()
-        remainder = [('SWITCHBOARD_%s' % k.upper(), v) for k, v in remainder]
+    def init(cls, **kwargs):
+        settings = kwargs.iteritems()
+        settings = [('SWITCHBOARD_%s' % k.upper(), v) for k, v in settings]
         # convert timeouts to ints
-        remainder = [(k, int(v) if k.endswith('TIMEOUT') else v)
-                     for k, v in remainder]
-        cls._state.update(dict(remainder))
+        settings = [(k, int(v) if k.endswith('TIMEOUT') else v)
+                    for k, v in settings]
+        cls._state.update(dict(settings))
         return cls()
 
     def __getattr__(self, name, default=NoValue):

--- a/switchboard/tests/test_base.py
+++ b/switchboard/tests/test_base.py
@@ -6,24 +6,20 @@ switchboard.tests.test_base
 :license: Apache License 2.0, see LICENSE for more details.
 """
 
-import time
-import threading
-
 from nose.tools import (
     assert_equals,
     assert_true,
     assert_false,
     assert_raises
 )
-from mock import Mock, patch
 from blinker import Signal
 
-from ..base import MongoModelDict, CachedDict
-from ..models import VersioningMongoModel
+from ..base import ModelDict
+from ..models import Model
 from ..signals import request_finished
 
 
-class MockModel(VersioningMongoModel):
+class MockModel(Model):
 
     def __init__(self, *args, **kwargs):
         self._attrs = []
@@ -32,17 +28,8 @@ class MockModel(VersioningMongoModel):
                 self._attrs.append(k)
                 setattr(self, k, v)
 
-    def to_bson(self):
-        data = {}
-        for a in self._attrs:
-            data[a] = getattr(self, a)
-        return data
-
     def __eq__(self, other):
         for a in self._attrs:
-            # don't really care if IDs match, at least not for the tests
-            if a == '_id':
-                continue
             if not hasattr(other, a):
                 return False
             if getattr(self, a) != getattr(other, a):
@@ -50,85 +37,71 @@ class MockModel(VersioningMongoModel):
         return True
 
 
-class TestMongoModelDict(object):
+class TestModelDict(object):
 
     def teardown(self):
-        MockModel.c.drop()
+        MockModel.drop()
 
-    def test_api(self):
+    def test_api_create(self):
         base_count = MockModel.count()
-
-        mydict = MongoModelDict(MockModel, key='key', value='value')
+        mydict = ModelDict(MockModel)
         mydict['foo'] = MockModel(key='foo', value='bar')
         assert_true(isinstance(mydict['foo'], MockModel))
-        assert_true(mydict['foo']._id)
+        assert_true(hasattr(mydict['foo'], 'key'))
         assert_equals(mydict['foo'].value, 'bar')
         assert_equals(MockModel.get(key='foo').value, 'bar')
         assert_equals(MockModel.count(), base_count + 1)
-        old_id = mydict['foo']._id
+
+    def test_api_update(self):
+        base_count = MockModel.count()
+        mydict = ModelDict(MockModel)
+        mydict['foo'] = MockModel(key='foo', value='bar')
+        old_key = mydict['foo'].key
         mydict['foo'] = MockModel(key='foo', value='bar2')
         assert_true(isinstance(mydict['foo'], MockModel))
-        assert_equals(mydict['foo']._id, old_id)
+        assert_equals(mydict['foo'].key, old_key)
         assert_equals(mydict['foo'].value, 'bar2')
         assert_equals(MockModel.get(key='foo').value, 'bar2')
         assert_equals(MockModel.count(), base_count + 1)
 
-        # test deletion
+    def test_api_delete(self):
+        base_count = MockModel.count()
+        mydict = ModelDict(MockModel)
+        mydict['foo'] = MockModel(key='foo', value='bar')
         mydict['foo'].delete()
         assert_true('foo' not in mydict)
-
-    def test_expirey(self):
-        base_count = MockModel.count()
-
-        mydict = MongoModelDict(MockModel, key='key', value='value')
-
-        assert_equals(mydict._cache, None)
-
-        instance = MockModel(key='test_expirey', value='hello')
-        mydict['test_expirey'] = instance
-
-        assert_equals(len(mydict._cache), base_count + 1)
-        assert_equals(mydict['test_expirey'], instance)
-
-        request_finished.send(Mock())
-
-        assert_equals(mydict._last_updated, None)
-        assert_equals(mydict['test_expirey'], instance)
-        assert_equals(len(mydict._cache), base_count + 1)
+        assert_equals(MockModel.count(), base_count)
 
     def test_no_auto_create(self):
         # without auto_create
-        mydict = MongoModelDict(MockModel, key='key', value='value')
+        mydict = ModelDict(MockModel)
         assert_raises(KeyError, lambda x: x['hello'], mydict)
         assert_equals(MockModel.count(), 0)
 
     def test_auto_create_no_value(self):
         # with auto_create and no value
-        mydict = MongoModelDict(MockModel, key='key', value='value',
-                                auto_create=True)
+        mydict = ModelDict(MockModel, auto_create=True)
         repr(mydict['hello'])
         assert_equals(MockModel.count(), 1)
         assert_false(hasattr(MockModel.get(key='hello'), 'value'), '')
 
     def test_auto_create(self):
         # with auto_create and value
-        mydict = MongoModelDict(MockModel, key='key', value='value',
-                                auto_create=True)
+        mydict = ModelDict(MockModel, auto_create=True)
         mydict['hello'] = MockModel(key='hello', value='foo')
         assert_equals(MockModel.count(), 1)
         assert_equals(MockModel.get(key='hello').value, 'foo')
 
     def test_save_behavior(self):
-        mydict = MongoModelDict(MockModel, key='key', value='value',
-                                auto_create=True)
-        mydict['hello'] = 'foo'
+        mydict = ModelDict(MockModel, auto_create=True)
+        mydict['hello'] = MockModel(key='hello')
         for n in xrange(10):
-            mydict[str(n)] = 'foo'
+            key = str(n) + '-model'
+            mydict[key] = MockModel(key=key)
         assert_equals(len(mydict), 11)
         assert_equals(MockModel.count(), 11)
 
-        mydict = MongoModelDict(MockModel, key='key', value='value',
-                                auto_create=True)
+        mydict = ModelDict(MockModel, auto_create=True)
         m = MockModel.get(key='hello')
         m.value = 'bar'
         m.save()
@@ -137,8 +110,7 @@ class TestMongoModelDict(object):
         assert_equals(len(mydict), 11)
         assert_equals(mydict['hello'].value, 'bar')
 
-        mydict = MongoModelDict(MockModel, key='key', value='value',
-                                auto_create=True)
+        mydict = ModelDict(MockModel, key='key', auto_create=True)
         m = MockModel.get(key='hello')
         m.value = 'bar2'
         m.save()
@@ -146,245 +118,3 @@ class TestMongoModelDict(object):
         assert_equals(MockModel.count(), 11)
         assert_equals(len(mydict), 11)
         assert_equals(mydict['hello'].value, 'bar2')
-
-    def test_signals_are_connected(self):
-        MongoModelDict(MockModel, key='key', value='value',
-                       auto_create=True)
-        post_save = VersioningMongoModel.post_save
-        post_delete = VersioningMongoModel.post_delete
-        assert_true(post_save.has_receivers_for(MockModel))
-        assert_true(post_delete.has_receivers_for(MockModel))
-        assert_true(request_finished.has_receivers_for(Signal.ANY))
-
-
-class TestCacheIntegration(object):
-    def setup(self):
-        self.cache = Mock()
-        self.cache.get.return_value = {}
-        self.mydict = MongoModelDict(MockModel, key='key', value='value',
-                                     auto_create=True)
-        self.mydict.cache = self.cache
-
-    def teardown(self):
-        MockModel.c.drop()
-
-    def test_model_creation(self):
-        instance = MockModel(key='hello', value='foo')
-        self.mydict['hello'] = instance
-        assert_equals(self.cache.get.call_count, 0)
-        assert_equals(self.cache.set.call_count, 2)
-        self.cache.set.assert_any_call(self.mydict.cache_key,
-                                       dict(hello=instance))
-        last_updated_key = self.mydict.last_updated_cache_key
-        self.cache.set.assert_any_call(last_updated_key,
-                                       self.mydict._last_updated)
-
-    def test_model_change(self):
-        self.mydict['hello'] = MockModel(key='hello', value='foo')
-        self.cache.reset_mock()
-        instance = MockModel(key='hello', value='bar')
-        self.mydict['hello'] = instance
-        assert_equals(self.cache.get.call_count, 0)
-        assert_equals(self.cache.set.call_count, 2)
-        self.cache.set.assert_any_call(self.mydict.cache_key,
-                                       dict(hello=instance))
-        last_updated_key = self.mydict.last_updated_cache_key
-        self.cache.set.assert_any_call(last_updated_key,
-                                       self.mydict._last_updated)
-
-    def test_model_delete(self):
-        self.mydict['hello'] = MockModel(key='hello', value='foo')
-        self.cache.reset_mock()
-        del self.mydict['hello']
-        assert_equals(self.cache.get.call_count, 0)
-        assert_equals(self.cache.set.call_count, 2)
-        self.cache.set.assert_any_call(self.mydict.cache_key, {})
-        last_updated_key = self.mydict.last_updated_cache_key
-        self.cache.set.assert_any_call(last_updated_key,
-                                       self.mydict._last_updated)
-
-    def test_model_access(self):
-        self.mydict['hello'] = MockModel(key='hello', value='foo')
-        self.cache.reset_mock()
-        foo = self.mydict['hello']
-        foo = self.mydict['hello']
-        foo = self.mydict['hello']
-        foo = self.mydict['hello']
-        assert_equals(foo.value, 'foo')
-        assert_equals(self.cache.get.call_count, 0)
-        assert_equals(self.cache.set.call_count, 0)
-
-    def test_model_access_without_cache(self):
-        spec = dict(key='hello', value='foo')
-        self.mydict['hello'] = MockModel(**spec)
-        self.mydict._cache = None
-        self.mydict._last_updated = None
-        self.cache.reset_mock()
-        foo = self.mydict['hello']
-        assert_equals(foo.value, 'foo')
-        assert_equals(self.cache.get.call_count, 2)
-        assert_equals(self.cache.set.call_count, 0)
-        self.cache.get.assert_any_call(self.mydict.cache_key)
-        self.cache.reset_mock()
-        foo = self.mydict['hello']
-        foo = self.mydict['hello']
-        foo = self.mydict['hello']
-        assert_equals(self.cache.get.call_count, 0)
-        assert_equals(self.cache.set.call_count, 0)
-
-    def test_model_access_with_expired_local_cache(self):
-        spec = dict(key='hello', value='foo')
-        self.mydict['hello'] = MockModel(**spec)
-        self.mydict._last_updated = None
-        self.cache.reset_mock()
-        foo = self.mydict['hello']
-        assert_equals(foo.value, 'foo')
-        assert_equals(self.cache.get.call_count, 1)
-        assert_equals(self.cache.set.call_count, 0)
-        self.cache.get.assert_any_call(self.mydict.last_updated_cache_key)
-        self.cache.reset_mock()
-        foo = self.mydict['hello']
-        foo = self.mydict['hello']
-        assert_equals(self.cache.get.call_count, 0)
-        assert_equals(self.cache.set.call_count, 0)
-
-
-class TestCachedDict(object):
-    def setup(self):
-        self.cache = Mock()
-        self.mydict = CachedDict(timeout=100)
-        self.mydict.cache =self.cache
-
-    @patch('switchboard.base.CachedDict._update_cache_data')
-    @patch('switchboard.base.CachedDict.is_local_expired',
-           Mock(return_value=True))
-    @patch('switchboard.base.CachedDict.has_global_changed',
-           Mock(return_value=True))
-    def test_error_causes_reset(self, _update_cache_data):
-        self.cache.get.return_value = 1
-        self.mydict._cache = {}
-        self.mydict._last_updated = time.time()
-        self.mydict._populate()
-
-        assert_true(_update_cache_data.called)
-
-    @patch('switchboard.base.CachedDict._update_cache_data')
-    @patch('switchboard.base.CachedDict.is_local_expired',
-           Mock(return_value=True))
-    @patch('switchboard.base.CachedDict.has_global_changed',
-           Mock(return_value=False))
-    def test_expired_does_update_data(self, _update_cache_data):
-        self.mydict._cache = {}
-        self.mydict._last_updated = time.time()
-        self.mydict._populate()
-
-        assert_false(_update_cache_data.called)
-
-    @patch('switchboard.base.CachedDict._update_cache_data')
-    @patch('switchboard.base.CachedDict.is_local_expired',
-           Mock(return_value=False))
-    @patch('switchboard.base.CachedDict.has_global_changed',
-           Mock(return_value=True))
-    def test_reset_does_expire(self, _update_cache_data):
-        self.mydict._cache = {}
-        self.mydict._last_updated = time.time()
-        self.mydict._populate(reset=True)
-
-        _update_cache_data.assert_called_once_with()
-
-    @patch('switchboard.base.CachedDict._update_cache_data')
-    @patch('switchboard.base.CachedDict.is_local_expired',
-           Mock(return_value=False))
-    @patch('switchboard.base.CachedDict.has_global_changed',
-           Mock(return_value=True))
-    def test_does_not_expire_by_default(self, _update_cache_data):
-        self.mydict._cache = {}
-        self.mydict._last_updated = time.time()
-        self.mydict._populate()
-
-        assert_false(_update_cache_data.called)
-
-    def test_is_expired_missing_last_updated(self):
-        self.mydict._last_updated = None
-        assert_true(self.mydict.is_local_expired())
-        assert_false(self.cache.get.called)
-
-    def test_is_expired_last_updated_beyond_timeout(self):
-        self.mydict._last_updated = time.time() - 101
-        assert_true(self.mydict.is_local_expired())
-
-    def test_is_expired_within_bounds(self):
-        self.mydict._last_updated = time.time()
-
-    def test_is_not_expired_if_remote_cache_is_old(self):
-        # set it to an expired time
-        self.mydict._last_updated = time.time() - 101
-        self.cache.get.return_value = self.mydict._last_updated
-
-        result = self.mydict.has_global_changed()
-
-        last_updated = self.mydict.last_updated_cache_key
-        self.cache.get.assert_called_once_with(last_updated)
-        assert_equals(result, False)
-
-    def test_is_expired_if_remote_cache_is_new(self):
-        # set it to an expired time
-        self.mydict._last_updated = time.time() - 101
-        self.cache.get.return_value = time.time()
-
-        result = self.mydict.has_global_changed()
-
-        last_updated = self.mydict.last_updated_cache_key
-        self.cache.get.assert_called_once_with(last_updated)
-        assert_equals(result, True)
-
-    @patch('switchboard.base.CachedDict._populate')
-    @patch('switchboard.base.CachedDict.get_default')
-    def test_returns_default_if_no_local_cache(self, get_default, populate):
-        get_default.return_value = 'bar'
-        value = self.mydict['foo']
-        assert_true(get_default.called)
-        assert_equals(value, 'bar')
-
-
-class TestCacheConcurrency(object):
-
-    def setup(self):
-        self.mydict = CachedDict()
-        self.exc = None
-
-    @patch('switchboard.base.CachedDict.get_cache_data')
-    def test_cache_reset_race(self, get_cache_data):
-        '''
-        Test race conditions when populating a cache.
-
-        Setup a situation where the cache is cleared immediately after being
-        populated, to simulate the race condition of one thread resetting it
-        just after another has populated it.
-        '''
-        get_cache_data.return_value = dict(key='test')
-        t2 = threading.Thread(target=self.mydict.clear_cache)
-
-        def verify_dict_access():
-            self.mydict._populate()
-            # Fire up the second thread and wait for it to clear the cache.
-            t2.start()
-            t2.join()
-            # Verify that the first thread's cache is still populated.
-            # Note: we don't call self.mydict['key'] because we don't want to
-            # re-trigger cache population.
-            # Note: Any errors (assertion or otherwise) must be surfaced up to
-            # the parent thread in order for nose to see that something went
-            # wrong.
-            try:
-                assert_true(self.mydict._cache,
-                            'The cache was reset between threads')
-                assert_equals(self.mydict._cache['key'], 'test')
-            except Exception as e:
-                self.exc = e
-
-        t1 = threading.Thread(target=verify_dict_access)
-        t1.start()
-        t1.join()
-        if self.exc:
-            raise self.exc

--- a/switchboard/tests/test_builtins.py
+++ b/switchboard/tests/test_builtins.py
@@ -20,7 +20,7 @@ from ..models import Switch, SELECTIVE
 
 
 def teardown_collection():
-    Switch.c.drop()
+    Switch.drop()
 
 
 class TestHostConditionSet(object):

--- a/switchboard/tests/test_models.py
+++ b/switchboard/tests/test_models.py
@@ -6,140 +6,39 @@ switchboard.tests.test_models
 :license: Apache License 2.0, see LICENSE for more details.
 """
 
-from datetime import datetime
-
 from nose.tools import assert_equals, assert_true, assert_false
-from mock import Mock, patch
+from mock import patch
 
 from ..manager import SwitchManager
-from ..models import MongoModel, VersioningMongoModel, Switch
+from ..models import Model
 
 
-class TestMongoModel(object):
+class TestModel(object):
     def setup(self):
-        self.m = MongoModel()
+        self.m = Model()
 
     def teardown(self):
-        MongoModel.c.drop()
+        Model.drop()
 
-    @patch('switchboard.models.MongoModel.update')
+    @patch('switchboard.models.Model.update')
     def test_get_or_create_get(self, update):
-        self.m.create(key=0, foo='bar')
+        self.m.create(key='0', foo='bar')
         defaults = dict(foo='bar')
-        instance, created = self.m.get_or_create(defaults=defaults, key=0)
+        instance, created = self.m.get_or_create('0', defaults=defaults)
         assert_false(created)
         assert_false(update.called)
         assert_equals(instance.foo, 'bar')
 
-    @patch('switchboard.models.MongoModel.update')
-    @patch('switchboard.helpers.MockCollection.find_one')
-    def test_get_or_create_create(self, find_one, update):
-        find_one.side_effect = [None, dict(foo='bar', key=0)]
+    @patch('switchboard.models.Model.update')
+    @patch('switchboard.models.Model.get')
+    def test_get_or_create_create(self, get, update):
+        get.return_value = None
+        update.return_value = Model(foo='bar', key='0')
         defaults = dict(foo='bar')
-        instance, created = self.m.get_or_create(defaults=defaults, key=0)
+        instance, created = self.m.get_or_create('0', defaults=defaults)
         assert_true(created)
         assert_true(update.called)
         assert_equals(instance.foo, 'bar')
-
-
-class TestVersioningMongoModel(object):
-    def setup(self):
-        self.m = VersioningMongoModel(_id='0')
-
-    def teardown(self):
-        VersioningMongoModel._versioned_collection().drop()
-
-    def test_diff_fields_added(self):
-        self.m.previous_version = lambda: VersioningMongoModel(a=1, b=2)
-        self.m.c.find_one = lambda x: dict(a=1, b=2, c=3)
-        delta = self.m._diff()
-        assert_equals(delta['added'], dict(c=3))
-
-    def test_diff_fields_deleted(self):
-        self.m.previous_version = lambda: VersioningMongoModel(a=1, b=2)
-        self.m.c.find_one = lambda x: dict(a=1)
-        delta = self.m._diff()
-        assert_equals(delta['deleted'], dict(b=2))
-
-    def test_diff_fields_changed(self):
-        self.m.previous_version = lambda: VersioningMongoModel(a=1, b=2)
-        self.m.c.find_one = lambda x: dict(a=1, b=3)
-        delta = self.m._diff()
-        assert_equals(delta['changed'], dict(b=(2, 3)))
-
-    def test_diff_fields_same(self):
-        self.m.previous_version = lambda: VersioningMongoModel(a=1, b=2)
-        self.m.c.find_one = lambda x: dict(a=1, b=2)
-        delta = self.m._diff()
-        assert_equals(delta['changed'], dict())
-        assert_equals(delta['added'], dict())
-        assert_equals(delta['deleted'], dict())
-
-    def test_diff_created(self):
-        self.m.previous_version = lambda: None
-        self.m.c.find_one = lambda x: dict(a=1, b=2)
-        delta = self.m._diff()
-        assert_equals(delta['changed'], dict())
-        assert_equals(delta['added'], dict(a=1, b=2))
-        assert_equals(delta['deleted'], dict())
-
-    def test_diff_removed(self):
-        self.m.previous_version = lambda: VersioningMongoModel(a=1, b=2)
-        self.m.c.find_one = lambda x: None
-        delta = self.m._diff()
-        assert_equals(delta['changed'], dict())
-        assert_equals(delta['added'], dict())
-        assert_equals(delta['deleted'], dict(a=1, b=2))
-
-    def test_diff_noop(self):
-        self.m.previous_version = lambda: None
-        self.m.c.find_one = lambda x: None
-        delta = self.m._diff()
-        assert_equals(delta, dict(added={}, deleted={}, changed={}))
-
-    def test_previous_version_new(self):
-        c = Mock()
-        c.find.return_value = None
-        self.m._versioned_collection = lambda: c
-        prev = self.m.previous_version()
-        assert_false(hasattr(prev, '_id'))
-
-    def test_previous_version_singlediff(self):
-        delta = dict(
-            added=dict(a=1, b=2)
-        )
-        c = Mock()
-        c.find.return_value = [dict(timestamp=datetime.utcnow(),
-                                    delta=delta)]
-        self.m._versioned_collection = lambda: c
-        prev = self.m.previous_version()
-        assert_equals(prev.a, 1)
-        assert_equals(prev.b, 2)
-
-    def test_previous_version_multidiff(self):
-        v1 = dict(
-            timestamp=datetime.utcnow(),
-            delta=dict(added=dict(a=1, b=2))
-        )
-        v2 = dict(
-            timestamp=datetime.utcnow(),
-            delta=dict(changed=dict(b=(2, 3)))
-        )
-        v3 = dict(
-            timestamp=datetime.utcnow(),
-            delta=dict(added=dict(c=4))
-        )
-        v4 = dict(
-            timestamp=datetime.utcnow(),
-            delta=dict(deleted=dict(a=1))
-        )
-        c = Mock()
-        c.find.return_value = [v1, v2, v3, v4]
-        self.m._versioned_collection = lambda: c
-        prev = self.m.previous_version()
-        assert_equals(prev.b, 3)
-        assert_equals(prev.c, 4)
-        assert_false(hasattr(prev, 'a'))
 
 
 class TestConstant(object):
@@ -165,26 +64,3 @@ class TestConstant(object):
     def test_exclude(self):
         assert_true(hasattr(self.operator, 'EXCLUDE'))
         assert_equals(self.operator.EXCLUDE, 'e')
-
-
-class TestSwitch(object):
-    def setup(self):
-        self.switch = Switch.create(key='test')
-
-    def teardown(self):
-        Switch.c.drop()
-        Switch._versioned_collection().drop()
-
-    def test_save_version_changed(self):
-        self.switch.key = 'test2'
-        self.switch.save()
-        _id = self.switch._id
-        assert_equals(self.switch.to_bson(),
-                      self.switch.c.find_one(dict(_id=_id)))
-        vc = self.switch._versioned_collection()
-        versions = list(vc.find(dict(switch_id=_id)))
-        assert_true(versions)
-        versions.sort(key=lambda x:x['timestamp'])
-        version = versions[-1]
-        assert_true(version)
-        assert_equals(version['delta']['changed']['key'], ('test', 'test2'))

--- a/switchboard/tests/test_testutils.py
+++ b/switchboard/tests/test_testutils.py
@@ -21,7 +21,7 @@ from ..testutils import switches
 
 
 def teardown_collection():
-    Switch.c.drop()
+    Switch.drop()
 
 
 class TestSwitchContextManager(object):


### PR DESCRIPTION
Fixes https://github.com/switchboardpy/switchboard/issues/16

The datastore library (https://github.com/datastore/datastore) lets
Switchboard be much more flexible about how the backend is arranged. Now
Switchboard can support file-based storage for easy local development
and much more complex, cached, sharded, multiple-layered datastores for
production environments.