### PR TITLE
Speedups for 1.x branch

### DIFF
--- a/docs/user-documentation.rst
+++ b/docs/user-documentation.rst
@@ -173,6 +173,17 @@ after a switch is changed and the cache is invalidated.
 Custom cache objects can be used instead of a memcache client, to implement different caching
 techniques.
 
+It is also possible to cache results of ``is_active`` calls.  This speeds up
+switchboard when the same switches are called multiple times, or when multiple
+child switches are used (so the parent will only be checked once).  The
+application is required to clear the cache, e.g. for each web request.  To
+enable ``is_active`` result caching do::
+
+    operator.result_cache = {}
+
+It is recommended to do that in the ``pre_request`` method of your switchboard
+`middleware`_ so that it is reset for each request.
+
 
 An Example
 ==========

--- a/switchboard/conditions.py
+++ b/switchboard/conditions.py
@@ -266,7 +266,7 @@ class ConditionSet(object):
         conditional is met, including a non-instance default.
         """
         return_value = None
-        for instance in itertools.chain(instances, [None]):
+        for instance in instances + [None]:
             if not self.can_execute(instance):
                 continue
             result = self.is_active(instance, condition)
@@ -282,13 +282,13 @@ class ConditionSet(object):
         a boolean representing if the feature is active.
         """
         return_value = None
-        for name, field in self.fields.iteritems():
-            field_conditions = condition.get(name)
-            if field_conditions:
+        for name, field_conditions in condition.iteritems():
+            field = self.fields.get(name)
+            if field:
                 value = self.get_field_value(instance, name)
                 for status, field_cond in field_conditions:
-                    exclude = status == EXCLUDE
                     if field.is_active(field_cond, value):
+                        exclude = status == EXCLUDE
                         if exclude:
                             return False
                         return_value = True

--- a/switchboard/conditions.py
+++ b/switchboard/conditions.py
@@ -261,8 +261,8 @@ class ConditionSet(object):
 
     def has_active_condition(self, condition, instances):
         """
-        Given a list of instances, and the conditions active for
-        this switch, returns a boolean reprsenting if any
+        Given a list of instances, and the condition active for
+        this switch, returns a boolean representing if the
         conditional is met, including a non-instance default.
         """
         return_value = None
@@ -278,7 +278,7 @@ class ConditionSet(object):
 
     def is_active(self, instance, condition):
         """
-        Given an instance, and the conditions active for this switch, returns
+        Given an instance, and the condition active for this switch, returns
         a boolean representing if the feature is active.
         """
         return_value = None

--- a/switchboard/conditions.py
+++ b/switchboard/conditions.py
@@ -259,7 +259,7 @@ class ConditionSet(object):
             value = value()
         return value
 
-    def has_active_condition(self, conditions, instances):
+    def has_active_condition(self, condition, instances):
         """
         Given a list of instances, and the conditions active for
         this switch, returns a boolean reprsenting if any
@@ -269,26 +269,26 @@ class ConditionSet(object):
         for instance in itertools.chain(instances, [None]):
             if not self.can_execute(instance):
                 continue
-            result = self.is_active(instance, conditions)
+            result = self.is_active(instance, condition)
             if result is False:
                 return False
             elif result is True:
                 return_value = True
         return return_value
 
-    def is_active(self, instance, conditions):
+    def is_active(self, instance, condition):
         """
         Given an instance, and the conditions active for this switch, returns
         a boolean representing if the feature is active.
         """
         return_value = None
         for name, field in self.fields.iteritems():
-            field_conditions = conditions.get(self.get_namespace(), {}).get(name)
+            field_conditions = condition.get(name)
             if field_conditions:
                 value = self.get_field_value(instance, name)
-                for status, condition in field_conditions:
+                for status, field_cond in field_conditions:
                     exclude = status == EXCLUDE
-                    if field.is_active(condition, value):
+                    if field.is_active(field_cond, value):
                         if exclude:
                             return False
                         return_value = True

--- a/switchboard/manager.py
+++ b/switchboard/manager.py
@@ -116,7 +116,8 @@ class SwitchManager(MongoModelDict):
                 try:
                     result = dic.get(cache_key)
                 except TypeError as e:  # not hashable
-                    log.debug('Switchboard result cache not active for this "%s" check due to: %s within args: %s', args[0], e, repr(cache_key)[:200])
+                    log.debug('Switchboard result cache not active for this "%s" check due to: %s within args: %s',
+                              args[0], e, repr(cache_key)[:200])
                     cache_key = None
                 else:
                     if result is not None:

--- a/switchboard/tests/test_manager.py
+++ b/switchboard/tests/test_manager.py
@@ -827,3 +827,57 @@ class TestManagerResultCaching(object):
         switch.status=GLOBAL
         switch.save()
         assert_false(self.operator.is_active('test'))
+
+
+class TestManagerResultCacheDecorator(object):
+
+    def setUp(self):
+        # gets a pure function, otherwise we get an unbound function that we can't call
+        self.with_result_cache = SwitchManager.__dict__['with_result_cache']
+
+        # a simple "is_active" to wrap
+        def is_active_func(self, key, *instances, **kwargs):
+            return True
+
+        # wrap it with the decorator
+        self.cached_is_active_func = self.with_result_cache(is_active_func)
+
+    def test_decorator_nocache(self):
+        operator_self = Mock(result_cache=None)
+        result = self.cached_is_active_func(operator_self, 'mykey')
+        assert_true(result)
+        assert_equals(operator_self.result_cache, None)
+
+    def test_decorator_simple(self):
+        operator_self = Mock(result_cache={})
+        result = self.cached_is_active_func(operator_self, 'mykey')
+        assert_true(result)
+        assert_equals(operator_self.result_cache, {
+            (('mykey',), ()): True
+        })
+
+    def test_decorator_uses_cache(self):
+        # put False in cache, to ensure only the cache is used, not is_active_func
+        operator_self = Mock(result_cache={
+            (('mykey',), ()): False
+        })
+        result = self.cached_is_active_func(operator_self, 'mykey')
+        assert_false(result)
+        assert_equals(operator_self.result_cache, {
+            (('mykey',), ()): False
+        })
+
+    def test_decorator_with_params(self):
+        operator_self = Mock(result_cache={})
+        result = self.cached_is_active_func(operator_self, 'mykey', 'someval', a=1, b=2)
+        assert_true(result)
+        assert_equals(operator_self.result_cache, {
+            (('mykey', 'someval'),
+             (('a', 1), ('b', 2))): True
+        })
+
+    def test_decorator_uncachable_params(self):
+        operator_self = Mock(result_cache={})
+        result = self.cached_is_active_func(operator_self, 'mykey', {})  # a dict isn't hashable, can't be cached
+        assert_true(result)
+        assert_equals(operator_self.result_cache, {})


### PR DESCRIPTION
Same as #50, but into the newly-created 1.x branch (which starts with the 1.3.7 release before the datastore changes)