### PR TITLE
Py3 fix for 1.x branch: hasattr() nuances

### DIFF
--- a/switchboard/manager.py
+++ b/switchboard/manager.py
@@ -260,18 +260,28 @@ class SwitchManager(MongoModelDict):
         create a switch history. Allows changes to switches to be audited.
         '''
         # Try to get the username from both User objects and user dicts.
+        user = self.context.get('user', {})
+        username = ''
+
         try:
-            user = self.context.get('user', {})
-            if hasattr(user, 'username'):
-                username = user.username
-            else:
-                username = user.get('username', '')
+            username = user.username
         except AttributeError:
-            username = ''
+            # doesn't have that attr, ok
+            pass
+        except Exception:
+            # @property username threw some other error
+            log.debug('Error when trying user.username attr', exc_info=True)
+
+        if not username:
+            try:
+                username = user.get('username', '')
+            except AttributeError:
+                # not a dict, ok
+                pass
 
         try:
             switch.save_version(username=username)
-        except:
+        except Exception:
             log.warning('Unable to save the switch version', exc_info=True)
 
 

--- a/switchboard/tests/test_manager.py
+++ b/switchboard/tests/test_manager.py
@@ -705,6 +705,17 @@ class TestAPI(object):
         self.operator.version_switch(switch)
         switch.save_version.assert_called_with(username=username)
 
+    def test_version_switch_user_class_properror(self):
+        class OurUser:
+            @property
+            def username(self):
+                raise IOError('whoops')
+        switch = Mock()
+        switch.save_version = Mock()
+        self.operator.context = dict(user=OurUser())
+        self.operator.version_switch(switch)
+        switch.save_version.assert_called_with(username='')
+
     def test_version_switch_nonuser_class(self):
         class NonUser:
             pass


### PR DESCRIPTION
On py2, hasattr() suppresses any errors, so we need to preserve that kind of behavior.  And hasattr() fully executes props so no point in using it to check first