### PR TITLE
admin ui: allow long key names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           - 3.8
           - 3.9
           - '3.10'
-          - '3.11-dev'
+          - '3.11'
 
     services:
       mongodb:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,9 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -70,7 +70,7 @@ jobs:
           SELENIUM_REMOTE=1 MUST_USE_REAL_MONGO=1 make functional-test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           flags: tests-${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,3 +76,4 @@ jobs:
           flags: tests-${{ matrix.python-version }}
           name: codecov-umbrella
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/example/tests.py
+++ b/example/tests.py
@@ -60,12 +60,12 @@ class TestAdmin:
     def teardown_class(cls):
         cls.b.quit()
 
-    def setup(self):
+    def setup_method(self):
         # Make sure the example switch is activated by at least
         # one visit.
         self.b.visit(url)
 
-    def teardown(self):
+    def teardown_method(self):
         Switch.c.drop()
 
     def test_root(self):

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     python_requires='>=3.7',

--- a/switchboard/admin/__init__.py
+++ b/switchboard/admin/__init__.py
@@ -73,12 +73,12 @@ def add():
     if not key:
         raise SwitchboardException("Key cannot be empty")
 
-    if len(key) > 32:
-        raise SwitchboardException("Key must be less than or equal to 32"
+    if len(key) > 1000:
+        raise SwitchboardException("Key must be less than or equal to 1000"
                                    + " characters in length")
 
-    if len(label) > 32:
-        raise SwitchboardException("Name must be less than or equal to 32"
+    if len(label) > 1000:
+        raise SwitchboardException("Name must be less than or equal to 1000"
                                    + " characters in length")
 
     if Switch.get(key=key):
@@ -106,12 +106,12 @@ def update():
 
     switch = Switch.get(key=curkey)
 
-    if len(key) > 32:
-        raise SwitchboardException("Key must be less than or equal to 32"
+    if len(key) > 1000:
+        raise SwitchboardException("Key must be less than or equal to 1000"
                                    + " characters in length")
 
-    if len(label) > 32:
-        raise SwitchboardException("Name must be less than or equal to 32"
+    if len(label) > 1000:
+        raise SwitchboardException("Name must be less than or equal to 1000"
                                    + " characters in length")
 
     values = dict(

--- a/switchboard/tests/test_base.py
+++ b/switchboard/tests/test_base.py
@@ -48,7 +48,7 @@ class MockModel(VersioningMongoModel):
 
 class TestMongoModelDict:
 
-    def teardown(self):
+    def teardown_method(self):
         MockModel.c.drop()
 
     def test_api(self):
@@ -154,14 +154,14 @@ class TestMongoModelDict:
 
 
 class TestCacheIntegration:
-    def setup(self):
+    def setup_method(self):
         self.cache = Mock()
         self.cache.get.return_value = {}
         self.mydict = MongoModelDict(MockModel, key='key', value='value',
                                      auto_create=True)
         self.mydict.cache = self.cache
 
-    def teardown(self):
+    def teardown_method(self):
         MockModel.c.drop()
 
     def test_model_creation(self):
@@ -246,7 +246,7 @@ class TestCacheIntegration:
 
 
 class TestCachedDict:
-    def setup(self):
+    def setup_method(self):
         self.cache = Mock()
         self.mydict = CachedDict(timeout=100)
         self.mydict.cache =self.cache
@@ -354,7 +354,7 @@ class TestCachedDict:
 
 class TestCacheConcurrency:
 
-    def setup(self):
+    def setup_method(self):
         self.mydict = CachedDict()
         self.exc = None
 

--- a/switchboard/tests/test_builtins.py
+++ b/switchboard/tests/test_builtins.py
@@ -28,7 +28,7 @@ def teardown_collection():
 
 
 class TestIPAddress:
-    def setup(self):
+    def setup_method(self):
         self.ip = IPAddress()
 
     def test_clean_valid_ipv4(self):
@@ -43,13 +43,13 @@ class TestIPAddress:
 
 
 class TestIPAddressConditionSet:
-    def setup(self):
+    def setup_method(self):
         self.cs = 'switchboard.builtins.IPAddressConditionSet'
         self.ip = '192.168.0.1'
         self.operator = SwitchManager(auto_create=True)
         self.operator.register(IPAddressConditionSet())
 
-    def teardown(self):
+    def teardown_method(self):
         teardown_collection()
 
     def test_ip_address(self):
@@ -102,11 +102,11 @@ class TestIPAddressConditionSet:
 
 
 class TestHostConditionSet:
-    def setup(self):
+    def setup_method(self):
         self.operator = SwitchManager(auto_create=True)
         self.operator.register(HostConditionSet())
 
-    def teardown(self):
+    def teardown_method(self):
         teardown_collection()
 
     def test_simple(self):
@@ -126,7 +126,7 @@ class TestHostConditionSet:
 
 
 class TestQueryStringConditionSet:
-    def setup(self):
+    def setup_method(self):
         self.operator = SwitchManager(auto_create=True)
         self.operator.register(QueryStringConditionSet())
 
@@ -144,7 +144,7 @@ class TestQueryStringConditionSet:
         )
         return switch
 
-    def teardown(self):
+    def teardown_method(self):
         teardown_collection()
 
     def test_flag_present(self):

--- a/switchboard/tests/test_conditions.py
+++ b/switchboard/tests/test_conditions.py
@@ -37,7 +37,7 @@ def test_titlize():
 
 
 class TestField:
-    def setup(self):
+    def setup_method(self):
         self.field = Field()
 
     def test_set_values(self):
@@ -66,7 +66,7 @@ class TestField:
 
 
 class TestBoolean:
-    def setup(self):
+    def setup_method(self):
         self.field = Boolean()
 
     def test_is_active(self):
@@ -82,7 +82,7 @@ class TestBoolean:
 
 
 class TestChoice:
-    def setup(self):
+    def setup_method(self):
         choices = ['foo', 'scooby']
         self.field = Choice(choices)
 
@@ -102,7 +102,7 @@ class TestChoice:
 
 
 class TestRange:
-    def setup(self):
+    def setup_method(self):
         self.field = Range()
         self.field.name = 'qi'
 
@@ -144,7 +144,7 @@ class TestRange:
 
 
 class TestPercent:
-    def setup(self):
+    def setup_method(self):
         self.field = Percent()
         self.field.label = 'Foo'
 
@@ -177,7 +177,7 @@ class TestPercent:
 
 
 class TestRegex:
-    def setup(self):
+    def setup_method(self):
         self.field = Regex()
         self.field.name = 'foo'
 
@@ -192,7 +192,7 @@ class TestRegex:
 
 
 class TestAbstractDate:
-    def setup(self):
+    def setup_method(self):
         self.field = AbstractDate()
 
     def test_str_to_date(self):
@@ -245,7 +245,7 @@ class TestAbstractDate:
 
 
 class TestBeforeDate:
-    def setup(self):
+    def setup_method(self):
         self.field = BeforeDate()
 
     def test_date_is_active(self):
@@ -258,7 +258,7 @@ class TestBeforeDate:
 
 
 class TestOnOrAfterDate:
-    def setup(self):
+    def setup_method(self):
         self.field = OnOrAfterDate()
 
     def test_date_is_active(self):
@@ -271,7 +271,7 @@ class TestOnOrAfterDate:
 
 
 class TestConditionSet:
-    def setup(self):
+    def setup_method(self):
         self.cs = ConditionSet()
 
     def test_get_field_value_str(self):
@@ -391,7 +391,7 @@ class TestConditionSet:
 
 
 class TestModelConditionSet:
-    def setup(self):
+    def setup_method(self):
         class OurModelConditionSet(ModelConditionSet):
             def get_namespace(self):
                 return 'ourmodel'
@@ -410,7 +410,7 @@ class TestModelConditionSet:
 
 
 class TestRequestConditionSet:
-    def setup(self):
+    def setup_method(self):
         self.cs = RequestConditionSet()
 
     def test_can_execute(self):

--- a/switchboard/tests/test_manager.py
+++ b/switchboard/tests/test_manager.py
@@ -30,7 +30,7 @@ from ..settings import settings
 
 
 class TestAPI:
-    def setup(self):
+    def setup_method(self):
         settings.SWITCHBOARD_SWITCH_DEFAULTS = {
             'active_by_default': {
                 'is_active': True,
@@ -48,7 +48,7 @@ class TestAPI:
         self.operator.register(IPAddressConditionSet)
         self.operator.register(HostConditionSet)
 
-    def teardown(self):
+    def teardown_method(self):
         Switch.c.drop()
 
     def test_builtin_registration(self):
@@ -737,7 +737,7 @@ class TestAPI:
 
 
 class TestConfigure:
-    def setup(self):
+    def setup_method(self):
         self.config = dict(
             mongo_host='mongodb',
             mongo_port=8080,
@@ -750,7 +750,7 @@ class TestConfigure:
             cache_hosts=['127.0.0.1']
         )
 
-    def teardown(self):
+    def teardown_method(self):
         Switch.c = MockCollection()
 
     def assert_settings(self):
@@ -790,7 +790,7 @@ class TestConfigure:
 
 class TestManagerConcurrency:
 
-    def setup(self):
+    def setup_method(self):
         self.operator = SwitchManager(auto_create=True)
         self.exc = None
 
@@ -821,7 +821,7 @@ class TestManagerConcurrency:
 
 class TestManagerResultCaching:
 
-    def setup(self):
+    def setup_method(self):
         self.operator = SwitchManager(auto_create=True)
         self.operator.result_cache = {}
 
@@ -849,7 +849,7 @@ class TestManagerResultCaching:
 
 class TestManagerResultCacheDecorator:
 
-    def setup(self):
+    def setup_method(self):
         # Gets a pure function, otherwise we get an unbound function that we
         # can't call.
         self.with_result_cache = SwitchManager.__dict__['with_result_cache']
@@ -906,7 +906,7 @@ class TestManagerResultCacheDecorator:
 
 
 class TestManagerConstants:
-    def setup(self):
+    def setup_method(self):
         self.operator = SwitchManager()
 
     def test_disabled(self):

--- a/switchboard/tests/test_middleware.py
+++ b/switchboard/tests/test_middleware.py
@@ -14,7 +14,7 @@ from ..middleware import SwitchboardMiddleware
 
 
 class TestSwitchboardMiddleware:
-    def setup(self):
+    def setup_method(self):
         self.app = Mock()
         self.middleware = SwitchboardMiddleware(self.app)
 

--- a/switchboard/tests/test_models.py
+++ b/switchboard/tests/test_models.py
@@ -23,10 +23,10 @@ from ..settings import settings
 
 
 class TestMongoModel:
-    def setup(self):
+    def setup_method(self):
         self.m = MongoModel()
 
-    def teardown(self):
+    def teardown_method(self):
         MongoModel.c.drop()
 
     @patch('switchboard.models.MongoModel.update')
@@ -50,10 +50,10 @@ class TestMongoModel:
 
 
 class TestVersioningMongoModel:
-    def setup(self):
+    def setup_method(self):
         self.m = VersioningMongoModel(_id='0')
 
-    def teardown(self):
+    def teardown_method(self):
         VersioningMongoModel._versioned_collection().drop()
 
     def test_diff_fields_added(self):
@@ -150,7 +150,7 @@ class TestVersioningMongoModel:
 
 
 class TestConstant:
-    def setup(self):
+    def setup_method(self):
         self.operator = SwitchManager()
 
     def test_disabled(self):
@@ -175,7 +175,7 @@ class TestConstant:
 
 
 class TestSwitch:
-    def setup(self):
+    def setup_method(self):
         self.condition_set = IPAddressConditionSet()
         self.manager = SwitchManager(auto_create=True)
         self.manager.register(self.condition_set)
@@ -191,7 +191,7 @@ class TestSwitch:
             ],
         }
 
-    def teardown(self):
+    def teardown_method(self):
         Switch.c.drop()
         Switch._versioned_collection().drop()
 

--- a/switchboard/tests/test_testutils.py
+++ b/switchboard/tests/test_testutils.py
@@ -20,10 +20,10 @@ def teardown_collection():
 
 
 class TestSwitchContextManager:
-    def setup(self):
+    def setup_method(self):
         self.operator = SwitchManager(auto_create=True)
 
-    def teardown(self):
+    def teardown_method(self):
         teardown_collection()
 
     def test_as_decorator(self):


### PR DESCRIPTION
Long switchboard keys work fine, so admin UI should allow them to be created