### PR TITLE
Also check referrer's query string for condition if request is ajax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ example/.switches
 .venv
 geckodriver.log
 server.pid
+.vscode

--- a/switchboard/tests/test_builtins.py
+++ b/switchboard/tests/test_builtins.py
@@ -175,3 +175,41 @@ class TestQueryStringConditionSet:
         req = Request.blank('/')
         self.setup_switch(req)
         assert not self.operator.is_active('test', req)
+
+    def test_referrer_POST(self):
+        req = Request.blank('/', method='POST', referrer='http://example.com/?alpha',
+                            headers={'Sec-Fetch-Mode': 'cors',
+                                     'Content-Type': 'application/x-www-form-urlencoded'})
+        self.setup_switch(req)
+        assert self.operator.is_active('test', req)
+
+    def test_referrer_combined(self):
+        req = Request.blank('/?beta', method='POST', referrer='http://example.com/?alpha',
+                            headers={'Sec-Fetch-Mode': 'cors',
+                                     'Content-Type': 'multipart/form-data'})
+        self.setup_switch(req)
+        assert self.operator.is_active('test', req)
+
+    def test_referrer_xhr_good(self):
+        req = Request.blank('/', referrer='http://example.com/?alpha',
+                            headers={'X-Requested-With': 'XMLHttpRequest'})
+        self.setup_switch(req)
+        assert self.operator.is_active('test', req)
+
+    def test_referrer_xhr_bad(self):
+        req = Request.blank('/', referrer='http://example.com/?alpha',
+                            headers={'X-Requested-With': 'OtherValue'})
+        self.setup_switch(req)
+        assert not self.operator.is_active('test', req)
+
+    def test_referrer_fetch_good(self):
+        req = Request.blank('/', referrer='http://example.com/?alpha',
+                            headers={'Sec-Fetch-Mode': 'cors'})
+        self.setup_switch(req)
+        assert self.operator.is_active('test', req)
+
+    def test_referrer_fetch_bad(self):
+        req = Request.blank('/', referrer='http://example.com/?alpha',
+                            headers={'Sec-Fetch-Mode': 'navigate'})
+        self.setup_switch(req)
+        assert not self.operator.is_active('test', req)

--- a/switchboard/tests/test_builtins.py
+++ b/switchboard/tests/test_builtins.py
@@ -178,14 +178,14 @@ class TestQueryStringConditionSet:
 
     def test_referrer_POST(self):
         req = Request.blank('/', method='POST', referrer='http://example.com/?alpha',
-                            headers={'Sec-Fetch-Mode': 'cors',
+                            headers={'Sec-Fetch-Mode': 'navigate',
                                      'Content-Type': 'application/x-www-form-urlencoded'})
         self.setup_switch(req)
         assert self.operator.is_active('test', req)
 
     def test_referrer_combined(self):
         req = Request.blank('/?beta', method='POST', referrer='http://example.com/?alpha',
-                            headers={'Sec-Fetch-Mode': 'cors',
+                            headers={'Sec-Fetch-Mode': 'navigate',
                                      'Content-Type': 'multipart/form-data'})
         self.setup_switch(req)
         assert self.operator.is_active('test', req)


### PR DESCRIPTION
It would make sense to allow switches that depend on query string values to check the query string of their referrer if relevant. 

This PR includes referrer's qs if: the request is a form POST or it's an ajax request.


## POST Detection
For POST, look at `request.method == 'POST'` and [Sec-Fetch-Mode](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode) should be `navigation`

## AJAX Detection
Can either be xhr or `fetch()`

### For XHR:
We can check that the header `X-Requested-With` exists w/ value `XMLHttpRequest`

### For fetch()
It's a little more complicated. There is a header [Sec-Fetch-Mode](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode) whose value can signal whether the request originated from a fetch call. Note that this does not distinguish much between various resources also fetched by the page (img, audio, etc.). But this probably won't hurt anything. Maybe resources respond to switches too.

The psuedeocode I went with is as follows:
```
is_ajax = (header['Sec-Fetch-Mode'] in ('cors', 'no-cors', 'same-origin'))
```

## Query String Combination
I've implemented a simple algorithm to combine. Pseudo code like so:
```
request.query + '&' + referrer.query
```